### PR TITLE
Added support for Pug extends and Pug includes

### DIFF
--- a/pug.rb
+++ b/pug.rb
@@ -18,7 +18,7 @@ module Jekyll
 
     def convert(content)
       begin
-        o, e, s = Open3.capture3("pug", :stdin_data => content)
+        o, e, s = Open3.capture3('pug -p .', :stdin_data => content)
         puts(<<-eos
 Pug Error >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 #{e}


### PR DESCRIPTION
Adding `-p .` to the pug command gives pug awareness to the current file's directory - which makes includes and extends possible.